### PR TITLE
Rewrite GC to handle Redis failures

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -41,6 +41,22 @@ The full list of settings is as follows.
 * <b><tt>socket</tt></b> - path to Unix socket if `unixsocket` is set
 
 
+## Development
+
+To run the tests, first start up a local Redis server running on port 16379.
+
+    $ redis-server spec/redis.conf
+    $ node spec/runner.js
+
+This engine does have some incompatibilities with the spec, and currently
+there are four known test failures:
+
+1. Redis engine destroyClient when the client has subscriptions stops the client receiving messages:
+2. Redis engine publish with a single wildcard delivers messages to matching subscriptions:
+3. Redis engine publish with a double wildcard delivers a unique copy of the message to each client:
+4. Redis engine publish with a double wildcard delivers messages to matching subscriptions:
+
+
 ## License
 
 (The MIT License)
@@ -63,4 +79,3 @@ FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
 COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
 IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-

--- a/faye-redis.js
+++ b/faye-redis.js
@@ -16,20 +16,6 @@ var multiRedis = function(urls) {
     var connection   = self.connect(options);
     var subscription = self.connect(options);
 
-    connection.on("reconnecting", function(reconnectionInfo) {
-      console.log("***** connection reconnecting -- " + options);
-    });
-    connection.on("error", function(err) {
-      console.log("***** connection error -- " + err + " -- " + options);
-    });
-
-    subscription.on("reconnecting", function(reconnectionInfo) {
-      console.log("***** subscription reconnecting -- " + options);
-    });
-    subscription.on("error", function(err) {
-      console.log("***** subscription error -- " + err + " -- " + options);
-    });
-
     self.connections[url]   = connection;
     self.subscriptions[url] = subscription;
   });

--- a/faye-redis.js
+++ b/faye-redis.js
@@ -218,6 +218,11 @@ Engine.prototype = {
   clientExists: function(clientId, callback, context) {
     var timeout = this._server.timeout;
 
+    if (clientId === undefined) {
+      this._server.debug("[RedisEngine#clientExists] undefined clientId, returning false");
+      return callback.call(context, false);
+    }
+
     this._redis.zscore(this._ns + '/clients', clientId, function(error, score) {
       if (timeout) {
         callback.call(context, score > new Date().getTime() - 1000 * 1.75 * timeout);

--- a/faye-redis.js
+++ b/faye-redis.js
@@ -304,7 +304,6 @@ Engine.prototype = {
           self._redis.rpush(self._ns + '/clients/' + clientId + '/messages', jsonMessage);
           self._redis.publish(self._ns + '/notifications', clientId);
           self._redis.expire(self._ns + '/clients/' + clientId + '/messages', 3600)
-          self._checkClient(clientId);
 
           notified.push(clientId);
         }
@@ -317,14 +316,6 @@ Engine.prototype = {
     });
 
     this._server.trigger('publish', message.clientId, message.channel, message.data);
-  },
-
-  _checkClient: function(clientId) {
-    var self = this;
-
-    this.clientExists(clientId, function(exists) {
-      if (!exists) self.destroyClient(clientId);
-    });
   },
 
   emptyQueue: function(clientId) {

--- a/faye-redis.js
+++ b/faye-redis.js
@@ -261,7 +261,7 @@ Engine.prototype = {
       }
 
       channels.forEach(function(channel) {
-        var channelsKey = this._ns + "/channels" + channel;
+        var channelsKey = self._ns + "/channels" + channel;
         self._redis.srem(channelsKey, clientId, function(error, res) {
           if (error) {
             return self._server.error("Failed to remove client ? from ?: ?", clientId, channelsKey, error);

--- a/faye-redis.js
+++ b/faye-redis.js
@@ -191,11 +191,13 @@ Engine.prototype = {
   },
 
   createClient: function(callback, context) {
-    var clientId = this._server.generateId(), self = this;
-    this._redis.zadd(this._ns + '/clients', 0, clientId, function(error, added) {
+    var clientId = this._server.generateId(),
+        score = new Date().getTime(),
+        self = this;
+
+    this._redis.zadd(this._ns + '/clients', score, clientId, function(error, added) {
       if (added === 0) return self.createClient(callback, context);
-      self._server.debug('Created new client ?', clientId);
-      self.ping(clientId);
+      self._server.debug('Created new client ? with score ?', clientId, score);
       self._server.trigger('handshake', clientId);
       callback.call(context, clientId);
     });

--- a/faye-redis.js
+++ b/faye-redis.js
@@ -338,7 +338,7 @@ Engine.prototype = {
     if (typeof timeout !== 'number') return;
 
     this._redis.urls.forEach(function(url) {
-      console.log("[" + url + "] Running GC");
+      this._server.debug("Running GC for ?", url);
       var connection = this._redis.connections[url];
 
       this._withLock(connection, 'gc', function(releaseLock) {
@@ -354,7 +354,7 @@ Engine.prototype = {
             this.destroyClient(clientId, function() {
               i += 1;
               if (i === n) {
-                console.log("[" + url + "] Destroyed " + n + " expired clients");
+                self._server.debug("Destroyed ? expired clients for ?", n, url);
                 releaseLock();
               }
             }, this);

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 , "author"          : "James Coglan <jcoglan@gmail.com> (http://jcoglan.com/)"
 , "keywords"        : ["pubsub", "bayeux"]
 
-, "version"         : "0.1.7"
+, "version"         : "0.1.8"
 , "engines"         : {"node": ">=0.4.0"}
 , "main"            : "./faye-redis"
 , "dependencies"    : {"hiredis": "", "redis": "", "consistent-hashing": ""}

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 , "author"          : "James Coglan <jcoglan@gmail.com> (http://jcoglan.com/)"
 , "keywords"        : ["pubsub", "bayeux"]
 
-, "version"         : "0.1.8"
+, "version"         : "0.1.9"
 , "engines"         : {"node": ">=0.4.0"}
 , "main"            : "./faye-redis"
 , "dependencies"    : {"hiredis": "", "redis": "", "consistent-hashing": ""}

--- a/spec/runner.js
+++ b/spec/runner.js
@@ -5,4 +5,6 @@ Faye = require('../vendor/faye/build/node/faye-node')
 require('../vendor/faye/spec/javascript/engine_spec')
 require('./faye_redis_spec')
 
+// Faye.Logging.logLevel = 'debug';
+
 JS.Test.autorun()


### PR DESCRIPTION
The most important change here is that Redis failures are now expected, and the entire GC/destroy client process has been updated to handle them. Broadly, failures are tolerated by allowing the GC to be re-runnable for a failed client ID.

When GC starts up, we fan out and call `destroyClient(clientId)` for each candidate expired client ID. Each one of these calls can fail individually, and processing simply stops for that client ID. Since the removal of the client ID from the `/clients` sorted set is the last step, GC will simply pickup failed client IDs and re-run them in the future. As such, the lock around GC has also been removed, since failures are expected and multiple deletion runs for a single client ID are tolerable.

Other notable changes:
- The score is now assigned to a client ID in the initial `ZADD` call in `createClient`. Previously, the score was assigned to zero, and updated in the callback with `ping()`. This is susceptible to a race, however, where GC can run and pluck the client ID before its score is updated.
- Publishing no longer destroys clients. Previously, publish would check the expiry of every client ID, and call `destroyClient` if it detected an expired client. This could lead to races, so it's now the sole responsibility of GC to cleanup old clients.
