### PR TITLE
0_2 - Allow passing of Redis client options / event listeners

### DIFF
--- a/faye-redis.js
+++ b/faye-redis.js
@@ -1,7 +1,7 @@
 // Constructor for multiRedis. It sets up two connections for each provided
 // Redis URL and adds them to a ketema ring. One connection is used for
 // commands and the other is used for pub/sub subscriptions.
-var multiRedis = function(urls) {
+var multiRedis = function(urls, redisClientOpts) {
   var hasher = require('hashring'),
       self   = this;
 
@@ -13,8 +13,8 @@ var multiRedis = function(urls) {
   urls.forEach(function(url) {
     var options = self.parse(url);
 
-    var connection   = self.connect(options);
-    var subscription = self.connect(options);
+    var connection   = self.connect(options, redisClientOpts);
+    var subscription = self.connect(options, redisClientOpts);
 
     self.connections[url]   = connection;
     self.subscriptions[url] = subscription;
@@ -72,9 +72,19 @@ multiRedis.prototype = {
   //   hostname: 'localhost',
   //   database: 0,
   //   password: 'chunkybacon' }
-  connect: function(server) {
+  connect: function(server, opts) {
     var redis      = require('redis'),
-        connection = redis.createClient(server.port, server.hostname);
+        connection = redis.createClient(server.port, server.hostname, opts);
+
+    // Listen for the events described in http://github.com/mranney/node_redis#Connection_Events
+    if ( opts.eventListeners )
+    {
+      for ( var listener in opts.eventListeners ) {
+        if ( opts.eventListeners.hasOwnProperty( listener ) && typeof opts.eventListeners[listener] === 'function' ) {
+          connection.on( listener, opts.eventListeners[listener] );
+        }
+      }
+    }  
 
     connection.select(server.database);
 
@@ -165,7 +175,7 @@ var Engine = function(server, options) {
 
   this._server     = server;
   this._ns         = this._options.namespace || '';
-  this._redis      = new multiRedis(options.servers);
+  this._redis      = new multiRedis(options.servers, options.redisClientOpts);
   this._onRedisError = this._options.onRedisError;
   this._statsd = this._options.statsd || NoStatsD;
 


### PR DESCRIPTION
Adds a `redisClientOpts` property to the engine config which uses the properties specified by [node_redis](http://github.com/mranney/node_redis#Connection_Events) such as `retry_max_delay`.

Also added an `eventListeners` option to `redisClientOpts` which lets you pass in event listeners. 
- Case in point: if you can't attach an `error` listener to a node_redis client, it throws an exception and cr ashes the server. This allows us to deal with that gracefully.
